### PR TITLE
Fixes to compile with clang-1205.0.22.9

### DIFF
--- a/sf2-split.cc
+++ b/sf2-split.cc
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
         }
       }
     }
-    delete wrFileName;
+    delete[] wrFileName;
   }
 
   munmap(data, stbuf.st_size);

--- a/sf2.h
+++ b/sf2.h
@@ -326,7 +326,7 @@ private:
   std::list<uint16_t> igenIdxList;
   std::list<uint16_t> shdrIdxList;
   std::map<uint16_t, uint16_t> shdrIdxMapper; // key:source / val:dest
-  std::map<uint32_t/*start*/, std::map<uint32_t/*end*/, uint32_t/*offset*/>> sampleAreas;
+  std::map<uint32_t/*start*/, std::map<uint32_t/*end*/, uint32_t/*offset*/> > sampleAreas;
 
   uint32_t sampleCountTotal;
 };

--- a/sf2filesplitter.cc
+++ b/sf2filesplitter.cc
@@ -53,7 +53,7 @@ char *SF2FileSplitter::createSplit(std::size_t &len)
   // 3. Actally write data to buffer
   if(!getLenOrWriteData(data, len)) {
     // Something went wrong: cleanup
-    delete data;
+    delete[] data;
     data = 0;
   }
   return data;
@@ -68,7 +68,7 @@ void SF2FileSplitter::addSampleAreaForSHDR(uint32_t shdrIdx)
   // sample area not yet inserted?
   bool bInsertNow = false;
   const sfSample_t& sample = hydra.getSample(shdrIdx);
-  std::map<uint32_t, std::map<uint32_t, uint32_t>>::iterator startIter;
+  std::map<uint32_t, std::map<uint32_t, uint32_t> >::iterator startIter;
   startIter = sampleAreas.find(sample.dwStart);
   // start found: Check if end not yet inserted
   if(startIter != sampleAreas.end()) {


### PR DESCRIPTION
Fixes for the following errors and warnings when compiling on MacOS:

```
In file included from sf2filesplitter.cc:2:
./sf2.h:329:75: error: a space is required between consecutive right angle brackets (use '> >')
  std::map<uint32_t/*start*/, std::map<uint32_t/*end*/, uint32_t/*offset*/>> sampleAreas;
                                                                          ^~
                                                                          > >
In file included from sf2.cc:2:
./sf2.h:329:75: error: a space is required between consecutive right angle brackets (use '> >')
  std::map<uint32_t/*start*/, std::map<uint32_t/*end*/, uint32_t/*offset*/>> sampleAreas;
                                                                          ^~
                                                                          > >
In file included from sf2-split.cc:2:
./sf2.h:329:75: error: a space is required between consecutive right angle brackets (use '> >')
  std::map<uint32_t/*start*/, std::map<uint32_t/*end*/, uint32_t/*offset*/>> sampleAreas;
                                                                          ^~
                                                                          > >
In file included from sf2-test.cc:2:
./sf2.h:329:75: error: a space is required between consecutive right angle brackets (use '> >')
  std::map<uint32_t/*start*/, std::map<uint32_t/*end*/, uint32_t/*offset*/>> sampleAreas;
                                                                          ^~
                                                                          > >
sf2filesplitter.cc:56:5: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
    delete data;
    ^
          []
sf2filesplitter.cc:51:16: note: allocated with 'new[]' here
  char *data = new char[len];
               ^
sf2filesplitter.cc:71:49: error: a space is required between consecutive right angle brackets (use '> >')
  std::map<uint32_t, std::map<uint32_t, uint32_t>>::iterator startIter;
                                                ^~
                                                > >
sf2-split.cc:101:5: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
    delete wrFileName;
    ^
          []
sf2-split.cc:60:24: note: allocated with 'new[]' here
    char* wrFileName = new char[strlen(argv[0])+1 + 3+1 + 3+1 + SF_NAME_LEN+1 +3 +1];
                       ^
```

